### PR TITLE
adjust test for pyhton2, hash, and pixel math

### DIFF
--- a/test/html_test.py
+++ b/test/html_test.py
@@ -1,7 +1,8 @@
 import fpdf
 import os
 import unittest
-
+from fpdf.html import px2mm
+from test.utilities import calculate_hash_of_file, set_doc_date_0
 
 class MyFPDF(fpdf.FPDF, fpdf.HTMLMixin):
   pass
@@ -11,18 +12,27 @@ class HTMLTest(unittest.TestCase):
   """This test executes some possible inputs to FPDF#HTMLMixin."""
   def test_html_images(self):
     pdf = MyFPDF()
+    set_doc_date_0(pdf)
     pdf.add_page()
-    img_path = f"{os.path.dirname(os.path.abspath(__file__))}/image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
+    rel = os.path.dirname(os.path.abspath(__file__))
+    img_path = rel + "/image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
+
+    initial = 10
+    mm_after_image = initial + px2mm(300)
     self.assertEqual(round(pdf.get_x()), 10, 'Initial x margin is not expected')
     self.assertEqual(round(pdf.get_y()), 10, 'Initial y margin is not expected')
     self.assertEqual(round(pdf.w), 210, 'Page width is not expected')
-    pdf.write_html(f"<center><img src={img_path} height='300' width='300'></center>")
+    pdf.write_html("<center><img src=\"%s\" height='300' width='300'></center>" % img_path)
     # Unable to text position of the image as write html moves to a new line after
     # adding the image but it can be seen in the produce test.pdf file.
     self.assertEqual(round(pdf.get_x()), 10, 'Have not moved to beginning of new line')
-    self.assertEqual(round(pdf.get_y()), 116, 'Image height has moved down the page')
+    self.assertAlmostEqual(pdf.get_y(), mm_after_image, places=2, msg='Image height has moved down the page')
     pdf.output('test/test.pdf', "F")
 
+    # comment to see view output after test
+    known_good_hash = "663ecbb2c23d55d4589629039d394911"
+    self.assertEqual(calculate_hash_of_file('test/test.pdf'), known_good_hash)
+    os.unlink('test/test.pdf')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
I clarified numbers and added the hash check that I made for all the other tests. I also changed the python3 syntax because originally this library was supposed to be python2 backwards compatible, and while there are no drastic changes going on im going to try to preserve that. tox passed all the tests for python27 and python36.